### PR TITLE
Update parsing for package declarations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn extract_headers(files: &Vec<String>) -> Vec<String> {
         .iter()
         .map(|file: &String| -> Vec<String> {
             file.lines()
-                .take_while(|line| line.starts_with("//#"))
+                .filter(|line| line.starts_with("//#"))
                 .map(|line| line[3..].trim_start().into())
                 .filter(|s: &String| !s.is_empty())
                 .collect()

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -57,6 +57,12 @@ pub(crate) struct Opt {
         raw(possible_values = r#"&["2015", "2018"]"#)
     )]
     pub edition: RustEdition,
+    #[structopt(long = "release")]
+    pub release: bool,
+    #[structopt(long = "cached")]
+    pub cached: bool,
+    #[structopt(short = "a", long = "arg", multiple = true)]
+    pub args: Vec<String>,
 }
 
 impl Opt {


### PR DESCRIPTION
Use `filter` instead of `take_while` to find all cargo-play
declarations.

Fixes #4 