### PR TITLE
Update parsing for package declarations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn extract_headers(files: &Vec<String>) -> Vec<String> {
         .iter()
         .map(|file: &String| -> Vec<String> {
             file.lines()
-                .take_while(|line| line.starts_with("//#"))
+                .filter(|line| line.starts_with("//#"))
                 .map(|line| line[3..].trim_start().into())
                 .filter(|s: &String| !s.is_empty())
                 .collect()


### PR DESCRIPTION
Use `filter` instead of `take_while` to find all cargo-play
declarations.

Fixes #4 