### PR TITLE
Add release, cached, and arg flags

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -57,6 +57,12 @@ pub(crate) struct Opt {
         raw(possible_values = r#"&["2015", "2018"]"#)
     )]
     pub edition: RustEdition,
+    #[structopt(long = "release")]
+    pub release: bool,
+    #[structopt(long = "cached")]
+    pub cached: bool,
+    #[structopt(short = "a", long = "arg", multiple = true)]
+    pub args: Vec<String>,
 }
 
 impl Opt {


### PR DESCRIPTION
`--release` compiles in release mode

`--cached` checks for an existing executable before executing

`-a, --arg` allows forward arguments to the program

Fixes #10 
Fixes #8 
Fixes #7 