### PR TITLE
Attempt to fix #20 - Add `--test` option to run only tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ fn main() -> Result<(), CargoPlayError> {
             opt.release,
             opt.cargo_option,
             &opt.args,
+            opt.test,
         )?
     };
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -53,6 +53,9 @@ pub struct Opt {
     #[structopt(short = "c", long = "clean")]
     /// Rebuild the cargo project without the cache from previous run
     pub clean: bool,
+    #[structopt(long = "test")]
+    /// Build and run only tests in module
+    pub test: bool,
     #[structopt(short = "t", long = "toolchain", hidden = true)]
     pub toolchain: Option<String>,
     #[structopt(

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -124,6 +124,7 @@ pub fn run_cargo_build(
     release: bool,
     cargo_option: Option<String>,
     program_args: &[String],
+    test: bool,
 ) -> Result<ExitStatus, CargoPlayError> {
     let mut cargo = Command::new("cargo");
 
@@ -131,8 +132,10 @@ pub fn run_cargo_build(
         cargo.arg(format!("+{}", toolchain));
     }
 
+    let subcommand = if test { "test" } else { "run" };
+
     cargo
-        .arg("run")
+        .arg(subcommand)
         .arg("--manifest-path")
         .arg(project.join("Cargo.toml"));
 


### PR DESCRIPTION
closes #20 

`cargo play /tmp/foo.rs --test`

```bash
❯ cargo run -- /tmp/foo.rs --test
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/cargo-play /tmp/foo.rs --test`
   Compiling zrdlphyoru90xzbqmq_csfkyiqs v0.1.0 (/tmp/cargo-play.zRdlPhYorU90XZbQmq_csfkyIqs)
    Finished test [unoptimized + debuginfo] target(s) in 0.20s
     Running /tmp/cargo-play.zRdlPhYorU90XZbQmq_csfkyIqs/target/debug/deps/zrdlphyoru90xzbqmq_csfkyiqs-fbc997d58fd5b0b9

running 2 tests
test test_foo ... ok
test test_bar ... FAILED

failures:

---- test_bar stdout ----
thread 'test_bar' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`', src/main.rs:12:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    test_bar

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out


```

![Screenshot_2020-03-20_13-19-23](https://user-images.githubusercontent.com/458654/77184121-1a850380-6aae-11ea-8076-fe036b440098.png)
