### PR TITLE
ensure that package names match Rust requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,21 +39,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "byteorder"
-version = "1.3.2"
+name = "bs58"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -68,7 +60,7 @@ dependencies = [
 name = "cargo-play"
 version = "0.4.0"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,9 +390,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b4b1549d804b6c73f4817df2ba073709e96e426f12987127c48e6745568c350b"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ structopt = "0.2"
 failure = "0.1"
 toml = "0.5"
 sha1 = "0.6"
-base64 = "0.10"
+bs58 = "0.3.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 pathdiff = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), CargoPlayError> {
     let opt = opt.unwrap();
 
     let src_hash = opt.src_hash();
+    let package_name = format!("p{}", src_hash);
     let temp = temp_dir(opt.temp_dirname());
 
     if opt.cached && temp.exists() {
@@ -32,7 +33,7 @@ fn main() -> Result<(), CargoPlayError> {
             bin_path.push("debug");
         }
         // TODO reuse logic to formulate package name, i.e. to_lowercase
-        bin_path.push(&src_hash.to_lowercase());
+        bin_path.push(&package_name.to_lowercase());
         if bin_path.exists() {
             let mut cmd = Command::new(bin_path);
             return cmd
@@ -58,7 +59,7 @@ fn main() -> Result<(), CargoPlayError> {
         rmtemp(&temp);
     }
     mktemp(&temp);
-    write_cargo_toml(&temp, src_hash.clone(), dependencies, opt.edition, infers)?;
+    write_cargo_toml(&temp, package_name, dependencies, opt.edition, infers)?;
     copy_sources(&temp, &opt.src)?;
 
     let end = if let Some(save) = opt.save {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -112,7 +112,7 @@ impl Opt {
             hash.update(file.to_string_lossy().as_bytes());
         }
 
-        base64::encode_config(&hash.digest().bytes()[..], base64::URL_SAFE_NO_PAD)
+        bs58::encode(hash.digest().bytes()).into_string()
     }
 
     pub fn temp_dirname(&self) -> PathBuf {


### PR DESCRIPTION
We can't have `-` characters in package names, and they can't start with a digit.