### PR TITLE
add expand mode to use cargo-expand

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -59,7 +59,7 @@ pub struct Options {
         short = "m",
         long = "mode",
         group = "modegroup",
-        possible_values = &["test", "check"]
+        possible_values = &["test", "check", "expand"]
     )]
     /// Specify run mode
     pub mode: Option<String>,
@@ -71,6 +71,11 @@ pub struct Options {
     /// Run code in check mode (alias to `--mode check`)
     #[structopt(long = "check", group = "modegroup")]
     pub check: bool,
+
+    /// Run code in expand mode (alias to `--mode expand`, requires
+    /// `cargo-expand` is installed)
+    #[structopt(long = "expand", group = "modegroup")]
+    pub expand: bool,
 
     #[structopt(short = "t", long = "toolchain", hidden = true)]
     pub toolchain: Option<String>,

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -145,6 +145,8 @@ pub fn run_cargo_build(options: &Options, project: &PathBuf) -> Result<ExitStatu
         "test"
     } else if options.check {
         "check"
+    } else if options.expand {
+        "expand"
     } else if let Some(mode) = options.mode.as_ref() {
         mode.as_str()
     } else {


### PR DESCRIPTION
I like to play around with how macros work, and `cargo-expand` (https://github.com/dtolnay/cargo-expand) is a great way to do this.

this pr adds an expand mode to use `cargo-expand`. When cargo expand is not installed, this is the error users get from the cargo subprocess:
```
error: no such subcommand: `expand`
```

Separately, I could just unconstrain the `possible_values` of the `--mode` flag (I tested, structopr appears to correctly handle the `modegroup` correctly in this case)